### PR TITLE
Fix endpoint trimming

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+	"strings"
 	"time"
 
 	"resty.dev/v3"
@@ -29,6 +30,7 @@ func New(endpoint, publicKey, secretKey string) LangfuseClient {
 func NewWithHttpClient(httpClient *http.Client, endpoint, publicKey, secretKey string) LangfuseClient {
 	client := resty.NewWithClient(httpClient).
 		SetBasicAuth(publicKey, secretKey)
+	endpoint = strings.TrimSuffix(endpoint, "/")
 	return &langfuseClient{
 		restClient:  client,
 		endpoint:    endpoint,


### PR DESCRIPTION
## Summary
- trim trailing slash from API endpoint

## Testing
- `go vet ./...` *(fails: download forbidden)*
- `go test ./...` *(fails: download forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_6845b8a6b45c8320a966c357a420a707