### PR TITLE
Update Go version in tests workflow

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.23'
+          go-version: '1.24'
       - run: go mod download
       - run: go test -v ./...
 
@@ -25,6 +25,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.23'
+          go-version: '1.24'
       - run: go mod download
       - run: go test -race -v ./...


### PR DESCRIPTION
## Summary
- update Go version from `1.23` to `1.24` in the GitHub Actions workflow

## Testing
- `go test ./...` *(fails: Forbidden download of Go 1.24.3)*

------
https://chatgpt.com/codex/tasks/task_b_6845b9bb265c832096ef5939f338b5fc